### PR TITLE
Add required PHP version to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Branch | Build status | Dev site
 * .travis.yml - Travis CI test suite configuration.
 
 ## Requirements
+* You need PHP ^7.1
 * Install composer: https://getcomposer.org/doc/00-intro.md
 * Install Drush version 8: http://docs.drush.org/en/master/install/
 * We are using Acquia BLT which has it's own set of requirements.


### PR DESCRIPTION
Unable to install site on PHP 7.0 because of some Symfony 4 and Doctrine 2.8 components used in composer.lock.