### PR TITLE
Fix issue #200: Tags for unpublished articles should not be displayed

### DIFF
--- a/config/default/views.view.blog_tags.yml
+++ b/config/default/views.view.blog_tags.yml
@@ -146,6 +146,44 @@ display:
           entity_type: taxonomy_term
           entity_field: vid
           plugin_id: bundle
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: reverse__node__field_tags
+          group_type: group
+          admin_label: 'Article must be published'
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
       sorts:
         nid:
           id: nid
@@ -176,6 +214,15 @@ display:
           required: false
           entity_type: taxonomy_term
           plugin_id: entity_reverse
+        field_tags:
+          id: field_tags
+          table: node__field_tags
+          field: field_tags
+          relationship: reverse__node__field_tags
+          group_type: group
+          admin_label: 'field_tags: Taxonomy term (relation to content)'
+          required: true
+          plugin_id: standard
       arguments: {  }
       display_extenders: {  }
       group_by: true


### PR DESCRIPTION
Update pro blog_tags view. Přidána reference a filtr na publikovaný obsah.