### PR TITLE
Set better quality of image styles than Drupal default

### DIFF
--- a/config/default/system.image.gd.yml
+++ b/config/default/system.image.gd.yml
@@ -1,2 +1,2 @@
-jpeg_quality: 75
+jpeg_quality: 95
 langcode: cs


### PR DESCRIPTION
JPG na 75 % kvality je v dnešní době málo. Dal bych 99 %, ale nechtěl jsem to hrotit, tak dávám 95 %.
Ono stačí, že kvalita dostává na frak tím, že jsou obrázky na DCZ zvětšované přes CSS nad svou velikost.