### PR TITLE
dcz-253: Make sure redirects are not covered by shield. Refs #253.

### DIFF
--- a/docroot/sites/default/settings/includes.settings.php
+++ b/docroot/sites/default/settings/includes.settings.php
@@ -37,9 +37,10 @@ $aliases = array(
 /**
  * Unshielded base URLs.
  */
-$unshielded = array(
-  $prod_base_url,
-);
+// Make sure redirects are not covered by shield.
+$unshielded = array_keys($aliases);
+// Unlock production.
+$unshielded[] = $prod_base_url;
 
 /**
  * Varnish.


### PR DESCRIPTION
Otestoval jsem domenu drupalasociace.cz po uprave /etc/hosts nez se rozbehne DNS a dostal jsem basic auth login form shieldu. Zmena zajisti ze redirecty probehnou bez shieldu.