### PR TITLE
Revert "fix(style): Set auto width for images"

### DIFF
--- a/docroot/themes/custom/dcz_theme/assets/sass/components/_images.scss
+++ b/docroot/themes/custom/dcz_theme/assets/sass/components/_images.scss
@@ -5,7 +5,8 @@
 }
 
 img {
-  width: auto;
+  height: auto;
+  width: 100%;
 }
 
 .embedded-entity .media--type-image img {

--- a/docroot/themes/custom/dcz_theme/css/style.css
+++ b/docroot/themes/custom/dcz_theme/css/style.css
@@ -573,7 +573,8 @@ form {
   display: none; }
 
 img {
-  width: auto; }
+  height: auto;
+  width: 100%; }
 
 .embedded-entity .media--type-image img {
   max-width: 100%;


### PR DESCRIPTION
Reverts Drupalcz/drupalcz#278
Automatická šířka negativně ovlivnila obrázky také na homepage, viz #294. Revertuji změny jako hotfix, než bude čas to udělat lépe a s více testy.